### PR TITLE
[ has braking change ] : use response structure onto api scope

### DIFF
--- a/src/controllers/apis/beekeepers.rs
+++ b/src/controllers/apis/beekeepers.rs
@@ -1,5 +1,6 @@
 use actix_web::{HttpRequest, Responder, HttpResponse};
 use crate::models::beekeeper::Beekeeper;
+use crate::controllers::apis::models::Beekeeper::Beekeeper as ApiBeekeeper;
 use crate::use_cases::apis::beekeepers::get_all_beekeepers_use_case;
 use serde::{Serialize, Deserialize};
 
@@ -11,7 +12,7 @@ pub async fn bk_index(httpReq: HttpRequest) -> impl Responder {
     let request = BeekeeperRequestModule{req: httpReq};
     let _ = request.to_request();
     let result: Vec<Beekeeper> = get_all_beekeepers_use_case::get_all();
-    let resultMod = BeekeeperResponseModule{beekeepers: result};
+    let resultMod = BeekeeperResponseModule{beekeepers: result}.to_response();
     HttpResponse::Ok().json(resultMod)
 }
 
@@ -30,12 +31,16 @@ impl BeekeeperRequestModule{
 // unmap from logic domain model to response type
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BeekeeperResponseModule{
-    pub beekeepers: Vec<Beekeeper>
+    beekeepers: Vec<Beekeeper>
 }
 
 impl BeekeeperResponseModule{
-    pub fn to_response(&self) -> Vec<Beekeeper>{
-        println!("{:?}", self.beekeepers);
-        self.beekeepers.to_vec()
+    pub fn to_response(&self) -> Vec<ApiBeekeeper>{
+        self.beekeepers.iter().map(|bk|{
+            ApiBeekeeper{
+                name: bk.name.name.clone(),
+                prefecture: bk.prefecture.name.name.clone()
+            }
+        }).collect()
     }
 }

--- a/src/controllers/apis/models.rs
+++ b/src/controllers/apis/models.rs
@@ -1,1 +1,2 @@
 pub mod Honey;
+pub mod Beekeeper;

--- a/src/controllers/apis/models/Beekeeper.rs
+++ b/src/controllers/apis/models/Beekeeper.rs
@@ -1,0 +1,9 @@
+use crate::models::beekeeper::Beekeeper as ModelBeekeeper;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Beekeeper {
+    pub name: String,
+    pub prefecture: String
+}
+


### PR DESCRIPTION
api returned structure in models scope. api and model should be split. So, we defined response module into api/models/Beekeeper